### PR TITLE
Working IAC Template for Azure

### DIFF
--- a/projects/env_automation/README.md
+++ b/projects/env_automation/README.md
@@ -1,6 +1,6 @@
 # Deploying NetworkStack with Cloudformation
 
-As I had already
+As I had already created a VPC with the required IP range for the bootcamp, I created a separate VPC for this exercise.
 
 ## Check Your AWS Account
 

--- a/projects/ip-address-management/README.md
+++ b/projects/ip-address-management/README.md
@@ -1,0 +1,3 @@
+# IP Address Management
+
+I created a Windows 2025 Server VM. I then exported its template and modified it so that be deployed using both Bicep and ARM templates.

--- a/projects/ip-address-management/journal.md
+++ b/projects/ip-address-management/journal.md
@@ -1,0 +1,152 @@
+# IP Address Management
+
+- [IP Address Management](#ip-address-management)
+  - [Find Appropriate VM for my region](#find-appropriate-vm-for-my-region)
+  - [Deploying the VM](#deploying-the-vm)
+    - [Bicep Deployment](#bicep-deployment)
+      - [Specifying Parameters in a Parameter File](#specifying-parameters-in-a-parameter-file)
+      - [Specifying Parameters on the command line](#specifying-parameters-on-the-command-line)
+  - [Building the Bicep file](#building-the-bicep-file)
+  - [Cleaning Up Resources](#cleaning-up-resources)
+    - [List all resources in the deployment](#list-all-resources-in-the-deployment)
+    - [List all resources in the resource group](#list-all-resources-in-the-resource-group)
+    - [Delete the deployment](#delete-the-deployment)
+
+## Find Appropriate VM for my region
+
+```shell
+az vm image list \
+  --publisher MicrosoftWindowsDesktop \
+  --offer windows11 \
+  --sku win11-22h2 \
+  --location ukwest \
+  --all \
+  --output table
+```
+
+## Deploying the VM
+
+I deployed the VM using the following commands:
+
+Before the VM can be deployed, we need to create a resource group. I wish to use the resource group `net-fun-bootcamp`.
+
+I had manually created the resource group `net-fun-bootcamp` in the Azure portal when deploying the VM.
+
+Even though the VM has been deleted, the resource group `net-fun-bootcamp` might still exist.
+
+We will check if the resource group exists:
+
+```bash
+az group exists --name net-fun-bootcamp
+```
+
+If it doesn't exist, create it:
+
+```bash
+az group create --name net-fun-bootcamp --location uksouth
+```
+
+Now we can deploy the VM:
+
+```bash
+cd projects/ip-address-management/templates/vm
+```
+
+To Deploy the VM using ARM Template:
+
+```bash
+az deployment group create \
+  --resource-group net-fun-bootcamp \
+  --template-file template.json \
+  --parameters @parameters.json
+```
+
+### Bicep Deployment
+
+To Deploy the VM using Bicep we can either use a parameter file or specify the parameters on the command line.
+
+#### Specifying Parameters in a Parameter File
+
+```bash
+az deployment group create \
+  --resource-group net-fun-bootcamp \
+  --template-file template.bicep \
+  --parameters @parameters.json \
+  --name net-fun-windows-server
+```
+
+#### Specifying Parameters on the command line
+
+```bash
+az deployment group create \
+  --resource-group net-fun-bootcamp \
+  --template-file template.bicep \
+  --parameters virtualMachines_net_fun_windows_server_name=net-fun-windows-server \
+  --parameters adminUsername=azureuser \
+  --parameters adminPassword=Password123! \
+  --name net-fun-windows-server
+```
+
+The VM was deployed successfully and I can see it in the Azure portal.
+
+## Building the Bicep file
+
+After deploying the VM using Bicep. I tried to deploy the VM using the ARM template but received the following error.
+
+```terminal
+az deployment group create \
+  --resource-group net-fun-bootcamp \
+  --template-file template.json \
+  --parameters @parameters.json
+The content for this response was already consumed
+```
+
+This is because the ARM template is not up to date with the Bicep file. We can build the Bicep file to regenerate the ARM template.
+
+```bash
+az bicep build -f template.bicep
+```
+
+## Cleaning Up Resources
+
+### List all resources in the deployment
+
+az deployment group show \
+  --resource-group net-fun-bootcamp \
+  --name net-fun-windows-server
+
+### List all resources in the resource group
+
+az resource list \
+  --resource-group net-fun-bootcamp
+
+### Delete the deployment
+
+To delete the VM and all its associated resources, use:
+
+```bash
+az vm delete \
+  --resource-group net-fun-bootcamp \
+  --name net-fun-windows-server \
+  --yes
+```
+
+This will delete:
+
+- The VM
+- The managed disk (if configured with delete option)
+- The network interface card (NIC)
+- The public IP address
+
+To verify the deletion:
+
+```bash
+# Check if VM exists
+az vm show \
+  --resource-group net-fun-bootcamp \
+  --name net-fun-windows-server
+
+# List remaining resources in the resource group
+az resource list \
+  --resource-group net-fun-bootcamp
+```

--- a/projects/ip-address-management/templates/vm/parameters.json
+++ b/projects/ip-address-management/templates/vm/parameters.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "virtualMachines_net_fun_windows_server_name": {
+            "value": "net-fun-windows-server"
+        },
+        "adminUsername": {
+            "value": "azureuser"
+        },
+        "adminPassword": {
+            "value": "Password123!"
+        },
+        "vnetAddressPrefix": {
+            "value": "10.0.0.0/16"
+        },
+        "subnetAddressPrefix": {
+            "value": "10.0.0.0/24"
+        }
+    }
+}

--- a/projects/ip-address-management/templates/vm/template.bicep
+++ b/projects/ip-address-management/templates/vm/template.bicep
@@ -1,0 +1,132 @@
+// Parameters
+param virtualMachines_net_fun_windows_server_name string = 'net-fun-windows-server'
+param adminUsername string
+@secure()
+param adminPassword string
+param vnetAddressPrefix string = '10.0.0.0/16'
+param subnetAddressPrefix string = '10.0.0.0/24'
+
+// Create Virtual Network
+resource vnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+  name: 'net-fun-vnet'
+  location: 'uksouth'
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnetAddressPrefix
+      ]
+    }
+    subnets: [
+      {
+        name: 'default'
+        properties: {
+          addressPrefix: subnetAddressPrefix
+        }
+      }
+    ]
+  }
+}
+
+// Create Public IP
+resource publicIp 'Microsoft.Network/publicIPAddresses@2023-04-01' = {
+  name: '${virtualMachines_net_fun_windows_server_name}-pip'
+  location: 'uksouth'
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Dynamic'
+    idleTimeoutInMinutes: 4
+  }
+}
+
+// Create a new NIC
+resource nic 'Microsoft.Network/networkInterfaces@2023-04-01' = {
+  name: '${virtualMachines_net_fun_windows_server_name}-nic'
+  location: 'uksouth'
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          privateIPAllocationMethod: 'Dynamic'
+          publicIPAddress: {
+            id: publicIp.id
+          }
+          subnet: {
+            id: vnet.properties.subnets[0].id
+          }
+        }
+      }
+    ]
+  }
+}
+
+// Create the VM
+// Create the VM
+resource virtualMachines_net_fun_windows_server_name_resource 'Microsoft.Compute/virtualMachines@2024-11-01' = {
+  name: virtualMachines_net_fun_windows_server_name
+  location: 'uksouth'
+  properties: {
+    hardwareProfile: {
+      vmSize: 'Standard_B2s'
+    }
+    additionalCapabilities: {
+      hibernationEnabled: false
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: 'MicrosoftWindowsServer'
+        offer: 'WindowsServer'
+        sku: '2025-datacenter-core-g2'
+        version: 'latest'
+      }
+      osDisk: {
+        osType: 'Windows'
+        name: '${virtualMachines_net_fun_windows_server_name}_OsDisk_1_cc494a0ac4184c4a9cf45f71d3ea845d'
+        createOption: 'FromImage'
+        caching: 'ReadWrite'
+        managedDisk: {
+          storageAccountType: 'Premium_LRS'
+        }
+        deleteOption: 'Delete'
+        diskSizeGB: 127
+      }
+      dataDisks: []
+      diskControllerType: 'SCSI'
+    }
+    osProfile: {
+      computerName: 'net-fun-windows'
+      adminUsername: adminUsername
+      adminPassword: adminPassword
+      windowsConfiguration: {
+        provisionVMAgent: true
+        enableAutomaticUpdates: true
+        patchSettings: {
+          patchMode: 'AutomaticByOS'
+          assessmentMode: 'ImageDefault'
+          enableHotpatching: false
+        }
+      }
+      secrets: []
+      allowExtensionOperations: true
+    }
+    securityProfile: {
+      uefiSettings: {
+        secureBootEnabled: true
+        vTpmEnabled: true
+      }
+      securityType: 'TrustedLaunch'
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: nic.id
+          properties: {
+            deleteOption: 'Delete'
+          }
+        }
+      ]
+    }
+  }
+}

--- a/projects/ip-address-management/templates/vm/template.json
+++ b/projects/ip-address-management/templates/vm/template.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.36.1.42791",
+      "templateHash": "13994607889413753831"
+    }
+  },
+  "parameters": {
+    "virtualMachines_net_fun_windows_server_name": {
+      "type": "string",
+      "defaultValue": "net-fun-windows-server"
+    },
+    "adminUsername": {
+      "type": "string"
+    },
+    "adminPassword": {
+      "type": "securestring"
+    },
+    "vnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16"
+    },
+    "subnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/24"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2023-04-01",
+      "name": "net-fun-vnet",
+      "location": "uksouth",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('vnetAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "default",
+            "properties": {
+              "addressPrefix": "[parameters('subnetAddressPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2023-04-01",
+      "name": "[format('{0}-pip', parameters('virtualMachines_net_fun_windows_server_name'))]",
+      "location": "uksouth",
+      "sku": {
+        "name": "Basic"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "idleTimeoutInMinutes": 4
+      }
+    },
+    {
+      "type": "Microsoft.Network/networkInterfaces",
+      "apiVersion": "2023-04-01",
+      "name": "[format('{0}-nic', parameters('virtualMachines_net_fun_windows_server_name'))]",
+      "location": "uksouth",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-pip', parameters('virtualMachines_net_fun_windows_server_name')))]"
+              },
+              "subnet": {
+                "id": "[reference(resourceId('Microsoft.Network/virtualNetworks', 'net-fun-vnet'), '2023-04-01').subnets[0].id]"
+              }
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-pip', parameters('virtualMachines_net_fun_windows_server_name')))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', 'net-fun-vnet')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines",
+      "apiVersion": "2024-11-01",
+      "name": "[parameters('virtualMachines_net_fun_windows_server_name')]",
+      "location": "uksouth",
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Standard_B2s"
+        },
+        "additionalCapabilities": {
+          "hibernationEnabled": false
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "MicrosoftWindowsServer",
+            "offer": "WindowsServer",
+            "sku": "2025-datacenter-core-g2",
+            "version": "latest"
+          },
+          "osDisk": {
+            "osType": "Windows",
+            "name": "[format('{0}_OsDisk_1_cc494a0ac4184c4a9cf45f71d3ea845d', parameters('virtualMachines_net_fun_windows_server_name'))]",
+            "createOption": "FromImage",
+            "caching": "ReadWrite",
+            "managedDisk": {
+              "storageAccountType": "Premium_LRS"
+            },
+            "deleteOption": "Delete",
+            "diskSizeGB": 127
+          },
+          "dataDisks": [],
+          "diskControllerType": "SCSI"
+        },
+        "osProfile": {
+          "computerName": "net-fun-windows",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "windowsConfiguration": {
+            "provisionVMAgent": true,
+            "enableAutomaticUpdates": true,
+            "patchSettings": {
+              "patchMode": "AutomaticByOS",
+              "assessmentMode": "ImageDefault",
+              "enableHotpatching": false
+            }
+          },
+          "secrets": [],
+          "allowExtensionOperations": true
+        },
+        "securityProfile": {
+          "uefiSettings": {
+            "secureBootEnabled": true,
+            "vTpmEnabled": true
+          },
+          "securityType": "TrustedLaunch"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('virtualMachines_net_fun_windows_server_name')))]",
+              "properties": {
+                "deleteOption": "Delete"
+              }
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": true
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('virtualMachines_net_fun_windows_server_name')))]"
+      ]
+    }
+  ]
+}

--- a/projects/ip-address-management/templates/vm/template_export.bicep
+++ b/projects/ip-address-management/templates/vm/template_export.bicep
@@ -1,0 +1,79 @@
+param virtualMachines_net_fun_windows_server_name string = 'net-fun-windows-server'
+param disks_net_fun_windows_server_OsDisk_1_cc494a0ac4184c4a9cf45f71d3ea845d_externalid string = '/subscriptions/a964c46c-2383-4126-b8c8-d4363f5d0d61/resourceGroups/net-fun-bootcamp/providers/Microsoft.Compute/disks/net-fun-windows-server_OsDisk_1_cc494a0ac4184c4a9cf45f71d3ea845d'
+param networkInterfaces_net_fun_windows_server91_z1_externalid string = '/subscriptions/a964c46c-2383-4126-b8c8-d4363f5d0d61/resourceGroups/net-fun-bootcamp/providers/Microsoft.Network/networkInterfaces/net-fun-windows-server91_z1'
+
+resource virtualMachines_net_fun_windows_server_name_resource 'Microsoft.Compute/virtualMachines@2024-11-01' = {
+  name: virtualMachines_net_fun_windows_server_name
+  location: 'uksouth'
+  zones: [
+    '1'
+  ]
+  properties: {
+    hardwareProfile: {
+      vmSize: 'Standard_B2s'
+    }
+    additionalCapabilities: {
+      hibernationEnabled: false
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: 'MicrosoftWindowsServer'
+        offer: 'WindowsServer'
+        sku: '2025-datacenter-core-g2'
+        version: 'latest'
+      }
+      osDisk: {
+        osType: 'Windows'
+        name: '${virtualMachines_net_fun_windows_server_name}_OsDisk_1_cc494a0ac4184c4a9cf45f71d3ea845d'
+        createOption: 'FromImage'
+        caching: 'ReadWrite'
+        managedDisk: {
+          storageAccountType: 'Premium_LRS'
+          id: disks_net_fun_windows_server_OsDisk_1_cc494a0ac4184c4a9cf45f71d3ea845d_externalid
+        }
+        deleteOption: 'Delete'
+        diskSizeGB: 127
+      }
+      dataDisks: []
+      diskControllerType: 'SCSI'
+    }
+    osProfile: {
+      computerName: 'net-fun-windows'
+      adminUsername: 'azureuser'
+      windowsConfiguration: {
+        provisionVMAgent: true
+        enableAutomaticUpdates: true
+        patchSettings: {
+          patchMode: 'AutomaticByOS'
+          assessmentMode: 'ImageDefault'
+          enableHotpatching: false
+        }
+      }
+      secrets: []
+      allowExtensionOperations: true
+      requireGuestProvisionSignal: true
+    }
+    securityProfile: {
+      uefiSettings: {
+        secureBootEnabled: true
+        vTpmEnabled: true
+      }
+      securityType: 'TrustedLaunch'
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: networkInterfaces_net_fun_windows_server91_z1_externalid
+          properties: {
+            deleteOption: 'Delete'
+          }
+        }
+      ]
+    }
+    diagnosticsProfile: {
+      bootDiagnostics: {
+        enabled: true
+      }
+    }
+  }
+}


### PR DESCRIPTION
# IP Address Management

- [IP Address Management](#ip-address-management)
  - [Find Appropriate VM for my region](#find-appropriate-vm-for-my-region)
  - [Deploying the VM](#deploying-the-vm)
    - [Bicep Deployment](#bicep-deployment)
      - [Specifying Parameters in a Parameter File](#specifying-parameters-in-a-parameter-file)
      - [Specifying Parameters on the command line](#specifying-parameters-on-the-command-line)
  - [Building the Bicep file](#building-the-bicep-file)
  - [Cleaning Up Resources](#cleaning-up-resources)
    - [List all resources in the deployment](#list-all-resources-in-the-deployment)
    - [List all resources in the resource group](#list-all-resources-in-the-resource-group)
    - [Delete the deployment](#delete-the-deployment)

## Find Appropriate VM for my region

```shell
az vm image list \
  --publisher MicrosoftWindowsDesktop \
  --offer windows11 \
  --sku win11-22h2 \
  --location ukwest \
  --all \
  --output table
```

## Deploying the VM

I deployed the VM using the following commands:

Before the VM can be deployed, we need to create a resource group. I wish to use the resource group `net-fun-bootcamp`.

I had manually created the resource group `net-fun-bootcamp` in the Azure portal when deploying the VM.

Even though the VM has been deleted, the resource group `net-fun-bootcamp` might still exist.

We will check if the resource group exists:

```bash
az group exists --name net-fun-bootcamp
```

If it doesn't exist, create it:

```bash
az group create --name net-fun-bootcamp --location uksouth
```

Now we can deploy the VM:

```bash
cd projects/ip-address-management/templates/vm
```

To Deploy the VM using ARM Template:

```bash
az deployment group create \
  --resource-group net-fun-bootcamp \
  --template-file template.json \
  --parameters @parameters.json
```

### Bicep Deployment

To Deploy the VM using Bicep we can either use a parameter file or specify the parameters on the command line.

#### Specifying Parameters in a Parameter File

```bash
az deployment group create \
  --resource-group net-fun-bootcamp \
  --template-file template.bicep \
  --parameters @parameters.json \
  --name net-fun-windows-server
```

#### Specifying Parameters on the command line

```bash
az deployment group create \
  --resource-group net-fun-bootcamp \
  --template-file template.bicep \
  --parameters virtualMachines_net_fun_windows_server_name=net-fun-windows-server \
  --parameters adminUsername=azureuser \
  --parameters adminPassword=Password123! \
  --name net-fun-windows-server
```

The VM was deployed successfully and I can see it in the Azure portal.

## Building the Bicep file

After deploying the VM using Bicep. I tried to deploy the VM using the ARM template but received the following error.

```terminal
az deployment group create \
  --resource-group net-fun-bootcamp \
  --template-file template.json \
  --parameters @parameters.json
The content for this response was already consumed
```

This is because the ARM template is not up to date with the Bicep file. We can build the Bicep file to regenerate the ARM template.

```bash
az bicep build -f template.bicep
```

## Cleaning Up Resources

### List all resources in the deployment

az deployment group show \
  --resource-group net-fun-bootcamp \
  --name net-fun-windows-server

### List all resources in the resource group

az resource list \
  --resource-group net-fun-bootcamp

### Delete the deployment

To delete the VM and all its associated resources, use:

```bash
az vm delete \
  --resource-group net-fun-bootcamp \
  --name net-fun-windows-server \
  --yes
```

This will delete:

- The VM
- The managed disk (if configured with delete option)
- The network interface card (NIC)
- The public IP address

To verify the deletion:

```bash
# Check if VM exists
az vm show \
  --resource-group net-fun-bootcamp \
  --name net-fun-windows-server

# List remaining resources in the resource group
az resource list \
  --resource-group net-fun-bootcamp
```
